### PR TITLE
fixed build issue of double definition of atomicAdd on modern GPUs

### DIFF
--- a/paddle/cuda/include/hl_device_functions.cuh
+++ b/paddle/cuda/include/hl_device_functions.cuh
@@ -16,6 +16,8 @@ limitations under the License. */
 #ifndef HL_DEVICE_FUNCTIONS_CUH_
 #define HL_DEVICE_FUNCTIONS_CUH_
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600
+
 namespace hppl {
 
 static __inline__ __device__ double atomicAdd(double* address, double val) {
@@ -37,5 +39,7 @@ static __inline__ __device__ double atomicAdd(double* address, double val) {
 }  // namespace hppl
 
 using hppl::atomicAdd;
+
+#endif
 
 #endif /* HL_DEVICE_FUNCTIONS_CUH_ */


### PR DESCRIPTION
Nvidia has implemented `atomicAdd` function in their CUDA utility, this PR can fix the build issue of duplicated definition of this function when building on modern GPUs equipped with the latest version of CUDA. 