### PR TITLE
Add travis support to PaddlePaddle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: cpp
+cache: ccache
+sudo: required
+dist: trusty
+addons:
+  apt:
+    packages:
+      - gcc-4.8
+      - g++-4.8
+      - wget
+      - git
+      - build-essential
+      - libatlas-base-dev
+      - python
+      - python-pip
+      - python2.7-dev
+      - m4
+      - libprotobuf-dev
+      - protobuf-compiler
+      - python-protobuf
+      - python-numpy
+      - python-wheel
+      - libgoogle-glog-dev
+      - libgflags-dev
+      - libgtest-dev
+before_install:
+  - pip install wheel protobuf
+  - sudo paddle/scripts/travis/before_install.sh
+script:
+  - paddle/scripts/travis/build.sh
+  - paddle/scripts/travis/unittest.sh
+notifications:
+  email:
+    on_success: change
+    on_failure: always

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(WITH_TIMER "Compile PaddlePaddle use timer" OFF)
 option(WITH_TESTING "Compile and run unittest for PaddlePaddle" ${GTEST_FOUND})
 option(WITH_DOC "Compile PaddlePaddle with documentation" OFF)
 option(WITH_SWIG_PY "Compile PaddlePaddle with py PaddlePaddle prediction api" ${SWIG_FOUND})
+option(ON_TRAVIS "Running test on travis-ci or not." OFF)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING 
         "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PaddlePaddle
+[![Build Status](https://travis-ci.org/baidu/Paddle.svg?branch=master)](https://travis-ci.org/baidu/Paddle)
 
 Welcome to the PaddlePaddle GitHub.
 

--- a/paddle/scripts/travis/before_install.sh
+++ b/paddle/scripts/travis/before_install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+pushd /usr/src/gtest
+cmake .
+make
+sudo cp *.a /usr/lib
+popd

--- a/paddle/scripts/travis/build.sh
+++ b/paddle/scripts/travis/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd `dirname $0`
+cd ../../../
+set -e
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DWITH_GPU=OFF -DWITH_DOC=OFF -DWITH_TESTING=ON -DON_TRAVIS=ON
+make -j `nproc`

--- a/paddle/scripts/travis/unittest.sh
+++ b/paddle/scripts/travis/unittest.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd `dirname $0`
+cd ../../../build
+env CTEST_OUTPUT_ON_FAILURE=1 make test ARGS="-j `nproc`"
+

--- a/paddle/trainer/tests/CMakeLists.txt
+++ b/paddle/trainer/tests/CMakeLists.txt
@@ -53,12 +53,13 @@ add_test(NAME test_CompareTwoOpts
 ################# test_CompareSparse ##################
 add_unittest_without_exec(test_CompareSparse
     test_CompareSparse.cpp)
-add_test(NAME test_CompareSparse
-  COMMAND ${PROJ_ROOT}/paddle/.set_python_path.sh -d ${PROJ_ROOT}/python/
-            ./.set_port.sh -p port -n 6
-                ${CMAKE_CURRENT_BINARY_DIR}/test_CompareSparse
+if(NOT ON_TRAVIS)
+  add_test(NAME test_CompareSparse
+    COMMAND ${PROJ_ROOT}/paddle/.set_python_path.sh -d ${PROJ_ROOT}/python/
+              ./.set_port.sh -p port -n 6
+                  ${CMAKE_CURRENT_BINARY_DIR}/test_CompareSparse
     WORKING_DIRECTORY ${PROJ_ROOT}/paddle/)
-
+endif()
 ################# test_recurrent_machine_generation ###############
 add_unittest_without_exec(test_recurrent_machine_generation
     test_recurrent_machine_generation.cpp)


### PR DESCRIPTION
Add travis-ci support to PaddlePaddle. The CPU version of it is under ci now.

But, the travis-ci server's memory cannot handle unittest test_CompareSparse. Just disable it now. And will rewrite it to use less memory.