### PR TITLE
Load all data before training for pool_size=-1

### DIFF
--- a/doc/ui/data_provider/pydataprovider2.rst
+++ b/doc/ui/data_provider/pydataprovider2.rst
@@ -162,7 +162,7 @@ PaddlePaddle from a user defined function. Its parameters are:
 * should_shuffle defines whether to shuffle data or not. By default, it is set
   true during training, and false during testing.
 * pool_size is the memory pool size (in sample number) in DataProvider.
-  -1 means no limit.
+  -1 means no limit and loading all data before training.
 * can_over_batch_size defines whether PaddlePaddle can store little more
   samples than pool_size. It is better to set True to avoid some deadlocks.
 * calc_batch_size is a function define how to calculate batch size. This is

--- a/doc/ui/data_provider/pydataprovider2.rst
+++ b/doc/ui/data_provider/pydataprovider2.rst
@@ -162,7 +162,9 @@ PaddlePaddle from a user defined function. Its parameters are:
 * should_shuffle defines whether to shuffle data or not. By default, it is set
   true during training, and false during testing.
 * pool_size is the memory pool size (in sample number) in DataProvider.
-  -1 means no limit and loading all data before training.
+  -1 means no limit and loading all data before training. If your original
+  data contains small number of files or not shuffled, you are not recommended
+  to set a different pool_size.
 * can_over_batch_size defines whether PaddlePaddle can store little more
   samples than pool_size. It is better to set True to avoid some deadlocks.
 * calc_batch_size is a function define how to calculate batch size. This is

--- a/python/paddle/trainer/PyDataProvider2.py
+++ b/python/paddle/trainer/PyDataProvider2.py
@@ -108,7 +108,7 @@ class SingleSlotWrapper(object):
 def provider(input_types=None, should_shuffle=True, pool_size=-1,
              can_over_batch_size=True,
              calc_batch_size=None,
-             cache=CacheType.NO_CACHE,
+             cache=CacheType.CACHE_PASS_IN_MEM,
              init_hook=None, **kwargs):
     """
     Provider decorator. Use it to make a function into PyDataProvider2 object.
@@ -133,6 +133,7 @@ def provider(input_types=None, should_shuffle=True, pool_size=-1,
     :param should_shuffle: True if data should shuffle.
     :type should_shuffle: bool
     :param pool_size: Max number of sample in data pool.
+                      -1 means loading all data before training.
     :type pool_size: int
     :param can_over_batch_size: True if paddle can return a mini-batch larger
                                 than batch size in settings. It is useful when

--- a/python/paddle/trainer/PyDataProvider2.py
+++ b/python/paddle/trainer/PyDataProvider2.py
@@ -133,7 +133,10 @@ def provider(input_types=None, should_shuffle=True, pool_size=-1,
     :param should_shuffle: True if data should shuffle.
     :type should_shuffle: bool
     :param pool_size: Max number of sample in data pool.
-                      -1 means loading all data before training.
+                      -1 means loading all data before training. If your
+                      original data contains small number of files or not
+                      shuffled, you are not recommended to set a different
+                      pool_size.
     :type pool_size: int
     :param can_over_batch_size: True if paddle can return a mini-batch larger
                                 than batch size in settings. It is useful when


### PR DESCRIPTION
This is to ensure there is no problem for shuffling when only partial data is loaded.