### PR TITLE
Fix signed/unsigned comparison for gcc 4.9

### DIFF
--- a/paddle/gserver/gradientmachines/RecurrentGradientMachine.cpp
+++ b/paddle/gserver/gradientmachines/RecurrentGradientMachine.cpp
@@ -676,7 +676,8 @@ void RecurrentGradientMachine::createInFrameInfo(int inlinkId,
   if (hasSubseq) {
     // inFrameLine create sequenceStartPositions one time
     CHECK_EQ(sequenceStartPositions.size(),
-             maxSequenceLength_ + input.getNumSubSequences());
+             static_cast<size_t>(maxSequenceLength_ +
+                                 input.getNumSubSequences()));
     CHECK_EQ(inlinkInfo->seqStartPosIndex.size(),
              static_cast<size_t>(maxSequenceLength_ + 1));
     createSeqPos(sequenceStartPositions, &inlinkInfo->sequenceStartPositions);


### PR DESCRIPTION
It's strange that my own gcc 5.4.0 and the travis continuous integration server's gcc 4.8.4 did not complain about this.