### PR TITLE
Fix potential dead lock in PyDataProvider2

### DIFF
--- a/paddle/utils/Logging.h
+++ b/paddle/utils/Logging.h
@@ -191,7 +191,7 @@ void installFailureWriter(void(*callback)(const char*, int));
 }
 #endif  // PADDLE_USE_GLOG
 
-#ifndef NDEBUG
+#ifdef NDEBUG
 #define DEBUG_LEVEL 5
 #define DBG VLOG(DEBUG_LEVEL)
 #else

--- a/paddle/utils/Util.h
+++ b/paddle/utils/Util.h
@@ -112,6 +112,17 @@ static bool contains(const Container& container, const T& val) {
   return std::find(container.begin(), container.end(), val) != container.end();
 }
 
+/**
+ * pop and get the front element of a container
+ */
+template<typename Container>
+typename Container::value_type pop_get_front(Container& c) {
+  typename Container::value_type v;
+  swap(v, c.front());
+  c.pop_front();
+  return v;
+}
+
 #define ARRAYSIZE(a) (sizeof(a) / sizeof(*(a)))
 
 /**


### PR DESCRIPTION
This bug occasionally causes dead lock in test_RecurrentGradientMachine
In general, conditional_variable::notify should be used together with mutex for changing condition.