### PR TITLE
Should not compile the two files if -DWITH_AVX=OFF.

### DIFF
--- a/paddle/cuda/CMakeLists.txt
+++ b/paddle/cuda/CMakeLists.txt
@@ -2,10 +2,17 @@ set(AVX_SOURCES
     src/hl_math.cc
     src/hl_avx_functions.cc
 )
+if(WITH_AVX)
 set(CUDA_SOURCES
     src/hl_time.cc
     src/hl_cpu_functions.cc
     ${AVX_SOURCES})
+else()
+set(CUDA_SOURCES
+    src/hl_time.cc
+    src/hl_cpu_functions.cc
+)
+endif()
 
 set(CUDA_CXX_WITH_GPU_SOURCES
     src/hl_cuda_cublas.cc

--- a/paddle/cuda/CMakeLists.txt
+++ b/paddle/cuda/CMakeLists.txt
@@ -2,16 +2,16 @@ set(AVX_SOURCES
     src/hl_math.cc
     src/hl_avx_functions.cc
 )
+
 if(WITH_AVX)
-set(CUDA_SOURCES
-    src/hl_time.cc
-    src/hl_cpu_functions.cc
-    ${AVX_SOURCES})
+    set(CUDA_SOURCES
+        src/hl_time.cc
+        src/hl_cpu_functions.cc
+        ${AVX_SOURCES})
 else()
-set(CUDA_SOURCES
-    src/hl_time.cc
-    src/hl_cpu_functions.cc
-)
+    set(CUDA_SOURCES
+        src/hl_time.cc
+        src/hl_cpu_functions.cc)
 endif()
 
 set(CUDA_CXX_WITH_GPU_SOURCES


### PR DESCRIPTION
If cmake -DWITH_AVX=OFF during configuration, should not compile the file src/hl_math.cc and src/hl_avx_functions.cc.