### PR TITLE
Feature/git version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,13 +67,16 @@ else()
         endif()
     elseif(EXISTS ${PROJ_ROOT}/.git/)
         find_package(Git REQUIRED)
-        if(GIT_FOUND)
-            execute_process(
-                COMMAND git log -1 --format=%H
-                WORKING_DIRECTORY ${PROJ_ROOT}
-                OUTPUT_VARIABLE GIT_SHA1
-                ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} log -1 --format=%H
+            WORKING_DIRECTORY ${PROJ_ROOT}
+            OUTPUT_VARIABLE GIT_SHA1
+            RESULT_VARIABLE GIT_RESULT
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(NOT ${GIT_RESULT})
             add_definitions(-DPADDLE_VERSION=\"${GIT_SHA1}\")
+        else()
+            message(WARNING "Cannot add paddle version from git tag")
         endif()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,16 @@ else()
             Subversion_WC_INFO(${PROJ_ROOT} Project)
             add_definitions(-DPADDLE_VERSION=${Project_WC_REVISION})
         endif()
+    elseif(EXISTS ${PROJ_ROOT}/.git/)
+        find_package(Git REQUIRED)
+        if(GIT_FOUND)
+            execute_process(
+                COMMAND git log -1 --format=%H
+                WORKING_DIRECTORY ${PROJ_ROOT}
+                OUTPUT_VARIABLE GIT_SHA1
+                ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+            add_definitions(-DPADDLE_VERSION=\"${GIT_SHA1}\")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
Add paddle version from git tag.
After each one batch training, the git sha1 will be write to file output/pass-XXXX/done
The done file is following:
paddle version:  1c2ebe467bb3c88b858f5b583ab48c8944c7f0f2
	withGpu: true
	withAvx: true
	withPyDataProvider: true
	withTimer: false
	withFpga: false
	real byte size: 4