### PR TITLE
Clean train

### DIFF
--- a/paddle/trainer/Trainer.cpp
+++ b/paddle/trainer/Trainer.cpp
@@ -90,14 +90,6 @@ namespace paddle {
 
 void Trainer::init(const std::shared_ptr<TrainerConfigHelper> &config,
                    bool testing) {
-  /// @TODO(yanfei): Clean this useless variable in next commit.
-  /// redundant parameters are removed, set nullptr with local variable
-  /// to verfiy that these there variables are useless.
-  /// Compiling Internal opensource/external opensource/metric learning passed
-  const std::shared_ptr<GradientMachine> &gradientMachine = nullptr;
-  const std::shared_ptr<DataProvider> &dataProvider = nullptr;
-  const std::shared_ptr<DataProvider> &testDataProvider = nullptr;
-
   this->stats_ = std::make_shared<TrainerStats>();
 
   config_ = config;
@@ -166,7 +158,7 @@ void Trainer::init(const std::shared_ptr<TrainerConfigHelper> &config,
   }
 
   // initialize trainer internal
-  trainerInternal_.init(config_, gradientMachine,
+  trainerInternal_.init(config_,
                         TrainerInternalConfig::createFromMode(mode_),
                         stats_, testing);
   std::unique_ptr<ParameterUtilConfig> paramConfig(
@@ -187,8 +179,7 @@ void Trainer::init(const std::shared_ptr<TrainerConfigHelper> &config,
                  (!IGradientMachineMode::dataMustInCpu(mode_,
                                                        FLAGS_trainer_count));
 
-  dataProvider_ = dataProvider;
-  if (!dataProvider_ && config_->hasDataConfig()) {
+  if (config_->hasDataConfig()) {
     dataProvider_.reset(DataProvider::create(*config_, *config_, gpuData));
   }
   if (dataProvider_) {
@@ -204,8 +195,7 @@ void Trainer::init(const std::shared_ptr<TrainerConfigHelper> &config,
     }
   }
 
-  testDataProvider_ = testDataProvider;
-  if (!testDataProvider_ && config_->hasTestDataConfig()) {
+  if (config_->hasTestDataConfig()) {
     testDataProvider_.reset(
         DataProvider::create(config_->getTestDataConfig(), *config_, gpuData));
   }

--- a/paddle/trainer/Trainer.cpp
+++ b/paddle/trainer/Trainer.cpp
@@ -88,15 +88,6 @@ P_DEFINE_string(model_list, "",
 
 namespace paddle {
 
-void Trainer::init(int argc, char** argv) {
-  initMain(argc, argv);
-  initPython(argc, argv);
-
-  auto config = TrainerConfigHelper::createFromFlagConfig();
-  feenableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
-
-  init(config);
-}
 
 void Trainer::init(const std::shared_ptr<TrainerConfigHelper> &config,
                    bool testing,

--- a/paddle/trainer/Trainer.cpp
+++ b/paddle/trainer/Trainer.cpp
@@ -88,12 +88,16 @@ P_DEFINE_string(model_list, "",
 
 namespace paddle {
 
-
 void Trainer::init(const std::shared_ptr<TrainerConfigHelper> &config,
-                   bool testing,
-                   const std::shared_ptr<GradientMachine> &gradientMachine,
-                   const std::shared_ptr<DataProvider> &dataProvider,
-                   const std::shared_ptr<DataProvider> &testDataProvider) {
+                   bool testing) {
+  /// @TODO(yanfei): Clean this useless variable in next commit.
+  /// redundant parameters are removed, set nullptr with local variable
+  /// to verfiy that these there variables are useless.
+  /// Compiling Internal opensource/external opensource/metric learning passed
+  const std::shared_ptr<GradientMachine> &gradientMachine = nullptr;
+  const std::shared_ptr<DataProvider> &dataProvider = nullptr;
+  const std::shared_ptr<DataProvider> &testDataProvider = nullptr;
+
   this->stats_ = std::make_shared<TrainerStats>();
 
   config_ = config;

--- a/paddle/trainer/Trainer.h
+++ b/paddle/trainer/Trainer.h
@@ -60,17 +60,10 @@ public:
    *
    * @param config TrainerConfig.
    * @param testing true if only for testing
-   * @param gradientMachine GradientMachine that will be trained.
-   *                        nullptr if create from config.
-   * @param dataProvider Train Data Provider. null if create from config.
-   * @param testDataProvider Test Data Provider. null if create from config.
    */
   virtual void init(
       const std::shared_ptr<TrainerConfigHelper> &config,
-      bool testing = false,
-      const std::shared_ptr<GradientMachine> &gradientMachine = nullptr,
-      const std::shared_ptr<DataProvider> &dataProvider = nullptr,
-      const std::shared_ptr<DataProvider> &testDataProvider = nullptr);
+      bool testing = false);
 
   /**
    * Train until num_passes reached.

--- a/paddle/trainer/Trainer.h
+++ b/paddle/trainer/Trainer.h
@@ -73,12 +73,6 @@ public:
       const std::shared_ptr<DataProvider> &testDataProvider = nullptr);
 
   /**
-   * Initialize Trainer from command line flags.
-   */
-  void init(int argc, char** argv);
-
-
-  /**
    * Train until num_passes reached.
    * One pass means neural network train through all training data.
    *

--- a/paddle/trainer/TrainerInternal.cpp
+++ b/paddle/trainer/TrainerInternal.cpp
@@ -38,7 +38,6 @@ limitations under the License. */
 namespace paddle {
 
 void TrainerInternal::init(const std::shared_ptr<TrainerConfigHelper> &config,
-                           const GradientMachinePtr &gradientMachine,
                            std::unique_ptr<TrainerInternalConfig> &&intconfig,
                            const std::shared_ptr<TrainerStats> &stats,
                            bool testing) {
@@ -53,12 +52,9 @@ void TrainerInternal::init(const std::shared_ptr<TrainerConfigHelper> &config,
       createParameterUpdater(testing);
     }
 
-    gradientMachine_ = gradientMachine;
-    if (!gradientMachine) {
-      gradientMachine_.reset(GradientMachine::create(
-        config_->getConfig().model_config(), intconfig_->mode,
-        parameterUpdater_->getParameterTypes()));
-    }
+   gradientMachine_.reset(GradientMachine::create(
+     config_->getConfig().model_config(), intconfig_->mode,
+     parameterUpdater_->getParameterTypes()));
 }
 
 void TrainerInternal::trainOneBatch(int64_t batchId,

--- a/paddle/trainer/TrainerInternal.h
+++ b/paddle/trainer/TrainerInternal.h
@@ -50,13 +50,11 @@ public:
   /**
    * Intializes trainer internal class
    * @param config network config
-   * @param machine gradient machine
    * @param intconfig training config
    * @param stats training stats
    * @param testing if it is in testing phase
    */
   void init(const std::shared_ptr<TrainerConfigHelper> &config,
-            const GradientMachinePtr &machine,
             std::unique_ptr<TrainerInternalConfig> &&intconfig,
             const std::shared_ptr<TrainerStats> &stats,
             bool testing);


### PR DESCRIPTION
I found 3 variables always are null, and verified it with source code and compiling. 

Check it within internal opensource, external opensource, metric learning usage..  Passed compilation. So, Just remove them ? 
Maybe I am wrong, but clean it necessary if I am right. 

@emailweixu @hedaoyuan @reyoung 