### PR TITLE
fix bug in some different python environment

### DIFF
--- a/paddle/gserver/dataproviders/PyDataProvider2.cpp
+++ b/paddle/gserver/dataproviders/PyDataProvider2.cpp
@@ -14,11 +14,11 @@ limitations under the License. */
 
 #ifndef PADDLE_NO_PYTHON
 
+#include <Python.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unordered_set>
 #include <list>
-#include <Python.h>
 #include <numpy/numpyconfig.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/ndarrayobject.h>


### PR DESCRIPTION
#207 will cause following error in my python environment:
```bash
In file included from /home/luotao/.jumbo/include/python2.7/Python.h:8:0,
                 from /home/luotao/Paddle/paddle/gserver/dataproviders/PyDataProvider2.cpp:21:
/home/luotao/.jumbo/include/python2.7/pyconfig.h:1161:0: error: "_POSIX_C_SOURCE" redefined [-Werror]
 #define _POSIX_C_SOURCE 200112L
 ^
In file included from /usr/include/stdio.h:28:0,
                 from /home/luotao/Paddle/paddle/gserver/dataproviders/PyDataProvider2.cpp:17:
/usr/include/features.h:162:0: note: this is the location of the previous definition
 # define _POSIX_C_SOURCE 200809L
 ^
In file included from /home/luotao/.jumbo/include/python2.7/Python.h:8:0,
                 from /home/luotao/Paddle/paddle/gserver/dataproviders/PyDataProvider2.cpp:21:
/home/luotao/.jumbo/include/python2.7/pyconfig.h:1183:0: error: "_XOPEN_SOURCE" redefined [-Werror]
 #define _XOPEN_SOURCE 600
 ^
In file included from /usr/include/stdio.h:28:0,
                 from /home/luotao/Paddle/paddle/gserver/dataproviders/PyDataProvider2.cpp:17:
/usr/include/features.h:164:0: note: this is the location of the previous definition
 # define _XOPEN_SOURCE 700
 ^
/home/luotao/Paddle/paddle/gserver/dataproviders/PyDataProvider2.cpp: In static member function 'static paddle::IPyDataProviderCache* paddle::IPyDataProviderCache::create(paddle::CacheType)':
/home/luotao/Paddle/paddle/gserver/dataproviders/PyDataProvider2.cpp:1064:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
/home/luotao/Paddle/paddle/gserver/dataproviders/PyDataProvider2.cpp: In member function 'virtual bool paddle::CacheOnePassInMemory::reset()':
/home/luotao/Paddle/paddle/gserver/dataproviders/PyDataProvider2.cpp:1034:3: error: control reaches end of non-void function [-Werror=return-type]
   }
   ^
cc1plus: all warnings being treated as errors
make[2]: *** [paddle/gserver/CMakeFiles/paddle_gserver.dir/dataproviders/PyDataProvider2.cpp.o] Error 1
make[1]: *** [paddle/gserver/CMakeFiles/paddle_gserver.dir/all] Error 2
make: *** [all] Error 2
```