### PR TITLE
fix build bug in gcc46

### DIFF
--- a/paddle/trainer/ThreadParameterUpdater.cpp
+++ b/paddle/trainer/ThreadParameterUpdater.cpp
@@ -258,7 +258,7 @@ void SgdThreadUpdater::threadUpdateSparse(
     }
     // For numThreads > 1, MultiGradientMachine is used, which goes
     // to the above branch.
-    CHECK_EQ(numThreads, 1);
+    CHECK_EQ(numThreads, 1UL);
     mainMat->clearIndices();
   } else {
     auto & m = *para->getMat(PARAMETER_GRADIENT).get();


### PR DESCRIPTION
when building PaddlePaddle in gcc46, user encounter following mistake:
```
[ 10%] Building CXX object paddle/trainer/CMakeFiles/paddle_trainer_lib.dir/ThreadParameterUpdater.cpp.o
In file included from /home/disk0/taozhipeng/paddle/baidu/idl/paddle/paddle/utils/Logging.h:183:0,
                 from /home/disk0/taozhipeng/paddle/baidu/idl/paddle/paddle/utils/Util.h:31,
                 from /home/disk0/taozhipeng/paddle/baidu/idl/paddle/paddle/trainer/ThreadParameterUpdater.h:18,
                 from /home/disk0/taozhipeng/paddle/baidu/idl/paddle/paddle/trainer/ThreadParameterUpdater.cpp:16:
/home/disk0/taozhipeng/.jumbo/include/glog/logging.h: In function 'std::string* google::Check_EQImpl(const T1&, const T2&, const char*) [with T1 = long unsigned int, T2 = long int, std::string = std::basic_string<char>]':
/home/disk0/taozhipeng/paddle/baidu/idl/paddle/paddle/trainer/ThreadParameterUpdater.cpp:261:175:   instantiated from here
/home/disk0/taozhipeng/.jumbo/include/glog/logging.h:694:122: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
cc1plus: all warnings being treated as errors
make64[2]: *** [paddle/trainer/CMakeFiles/paddle_trainer_lib.dir/ThreadParameterUpdater.cpp.o] Error 1
make64[1]: *** [paddle/trainer/CMakeFiles/paddle_trainer_lib.dir/all] Error 2
make64: *** [all] Error 2
```