### PR TITLE
FIx check type unmatch in MaxOutLayer

### DIFF
--- a/paddle/gserver/layers/MaxOutLayer.cpp
+++ b/paddle/gserver/layers/MaxOutLayer.cpp
@@ -46,7 +46,7 @@ bool MaxOutLayer::init(const LayerMap& layerMap,
   Layer::init(layerMap, parameterMap);
 
   /* the size of inputs for maxout-layer is 1 */
-  CHECK_EQ(config_.inputs_size(), 1UL);
+  CHECK_EQ(config_.inputs_size(), 1);
 
   const MaxOutConfig& conf = config_.inputs(0).maxout_conf();
   groups_ = conf.groups();


### PR DESCRIPTION
Compiled failed on gcc 4.6