### PR TITLE
add input sparse data check for sparse layer at runtime

### DIFF
--- a/paddle/math/SparseRowMatrix.cpp
+++ b/paddle/math/SparseRowMatrix.cpp
@@ -227,6 +227,12 @@ void CacheRowCpuMatrix::mul(CpuSparseMatrix* a, CpuMatrix* b, real scaleAB,
 
 void SparsePrefetchRowCpuMatrix::addRows(const unsigned int* ids, size_t len) {
   std::vector<unsigned int>& localIndices = indexDictHandle_->localIndices;
+  for (size_t i = 0; i < len; i ++) {
+    CHECK_LT(*(ids + i), this->getHeight())
+      << "id:" << *(ids + i) << "Height:" << this->getHeight()
+      << "sparse id value exceeds the max input dimension, "
+      << "it could be caused invalid input data samples";
+  }
   localIndices.insert(localIndices.end(), ids, ids + len);
 }
 
@@ -243,7 +249,13 @@ void SparsePrefetchRowCpuMatrix::addRows(IVectorPtr ids) {
   int* index = ids->getData();
   for (size_t i = 0; i < numSamples; ++i) {
     if (index[i] == -1) continue;
-    localIndices.push_back((unsigned int)index[i]);
+
+    unsigned int id = (unsigned int)index[i];
+    CHECK_LT(id, this->getHeight())
+      << "id:" << id << "Height:" << this->getHeight()
+      << "sparse id value exceeds the max input dimension, "
+      << "it could be caused invalid input data samples";
+    localIndices.push_back(id);
   }
 }
 

--- a/paddle/math/SparseRowMatrix.cpp
+++ b/paddle/math/SparseRowMatrix.cpp
@@ -238,7 +238,7 @@ void SparsePrefetchRowCpuMatrix::addRows(const unsigned int* ids, size_t len) {
 
 void SparsePrefetchRowCpuMatrix::addRows(MatrixPtr input) {
   CpuSparseMatrix* mat = dynamic_cast<CpuSparseMatrix*>(input.get());
-  CHECK(mat) << "only support non value sparse matrix";
+  CHECK(mat) << "only support sparse matrix";
   addRows(reinterpret_cast<const unsigned int*>(mat->getCols()),
           mat->getElementCnt());
 }


### PR DESCRIPTION
To avoid invalid data access at pserver end while doing prefetch. It could be helpful to understand crash at pserver end.

we implement the check at prefetch stage, so that we will have little performance penalty, because the data traversal is also done by prefetch. 

TEST PASS using user's real data: 
With  setting:
data = data_layer(name="feature", size=908559). 
hidden1 = fc_layer(input=data,
                    size=8,
                    param_attr=ParameterAttribute(sparse_update=True))

the patch will capture the error sample in advance, otherwise the perver could crashed with unreadable LOG.

SparseRowMatrix.cpp:231] Check failed: (*(ids + i)) < (this->getHeight()) id:6919838Height:908559sparse id value exceeds the max input dimension, it could be caused invalid input data samples


