### PR TITLE
set test_period default value to 0

### DIFF
--- a/paddle/trainer/Trainer.cpp
+++ b/paddle/trainer/Trainer.cpp
@@ -40,7 +40,7 @@ limitations under the License. */
 #include "TrainerConfigHelper.h"
 
 P_DEFINE_string(config, "", "Trainer config file");
-P_DEFINE_int32(test_period, 1000,
+P_DEFINE_int32(test_period, 0,
                "Run test every so many train batches."
                " 0 for testing after each pass."
                " If not 0, test log_period batches."


### PR DESCRIPTION
Original default value 1000 for test_period is confusing sometimes. Generally, by default user probably understand that executing test at the end of pass. 

In following real case, after the 1000 batches passed, Test output confusing result.  
related issue: https://github.com/baidu/Paddle/issues/266.

```
I /home/wangyanfei/baidu/idl/paddle/paddle/trainer/TrainerInternal.cpp:162]  Batch=1000 samples=40000000 AvgCost=0.0601279 CurrentCost=0.0601842 Eval: __auc_evaluator_0__=0.744762  CurrentEval: __auc_evaluator_0__=0.737961
I /home/wangyanfei/baidu/idl/paddle/paddle/trainer/Tester.cpp:111]  Test samples=10877807 cost=0.0629342 Eval: __auc_evaluator_0__=0.679616
7268477
...................
I /home/wangyanfei/baidu/idl/paddle/paddle/trainer/TrainerInternal.cpp:162]  Batch=1020 samples=40800000 AvgCost=0.0600301 CurrentCost=0.055141 Eval: __auc_evaluator_0__=0.745932  CurrentEval: __auc_evaluator_0__=0.822079
...................
I /home/wangyanfei/baidu/idl/paddle/paddle/trainer/TrainerInternal.cpp:162]  Batch=1040 samples=41600000 AvgCost=0.0598805 CurrentCost=0.052249 Eval: __auc_evaluator_0__=0.74747  CurrentEval: __auc_evaluator_0__=0.822162
...................
I /home/wangyanfei/baidu/idl/paddle/paddle/trainer/TrainerInternal.cpp:162]  Batch=1060 samples=42400000 AvgCost=0.0597376 CurrentCost=0.0523061 Eval: __auc_evaluator_0__=0.748938  CurrentEval: __auc_evaluator_0__=0.821579
...................
I /home/wangyanfei/baidu/idl/paddle/paddle/trainer/TrainerInternal.cpp:162]  Batch=1080 samples=43200000 AvgCost=0.0596102 CurrentCost=0.05286 Eval: __auc_evaluator_0__=0.750258  CurrentEval: __auc_evaluator_0__=0.816608
..............I /home/wangyanfei/baidu/idl/paddle/paddle/trainer/TrainerInternal.cpp:179]  Pass=7 Batch=1094 samples=43721520 AvgCost=0.0595306 Eval: __auc_evaluator_0__=0.751041
I /home/wangyanfei/baidu/idl/paddle/paddle/trainer/Tester.cpp:111]  Test samples=10877807 cost=0.0704427 Eval: __auc_evaluator_0__=0.674934
I /home/wangyanfei/baidu/idl/paddle/paddle/gserver/gradientmachines/GradientMachine.cpp:112] Saving parameters to ./output/pass-00007
I /home/wangyanfei/baidu/idl/paddle/paddle/utils/Util.cpp:213] copy trainer_config.lr.py to ./output/pass-00007
```