### PR TITLE
Bugfix in finding python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.2)
 
 project(paddle CXX C)
 set(PADDLE_MAJOR_VERSION 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 project(paddle CXX C)
 set(PADDLE_MAJOR_VERSION 0)


### PR DESCRIPTION
PR for issue https://github.com/baidu/Paddle/issues/297

*  the issue that find_package(PythonLibs 2.7 REQUIRED) and find_package(PythonInterp 2.7       REQUIRED) could find different python is BUG in CMAKE, instead of PaddlePaddle.
Related BUGs:
```
http://public.kitware.com/pipermail/cmake/2015-December/062387.html
https://cmake.org/Bug/view.php?id=14809
https://cmake.org/Bug/view.php?id=13794
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=677598
https://github.com/Valloric/YouCompleteMe/issues/1307
```
But, the solution is not clear. 

Solution I prefer: 
*  Set CMake min version to 3.2 in CMakeList.txt
```
 cmake_minimum_required(VERSION 3.2) 
```
* use CMAKE_PREFIX_PATH= to restrict python selection in external compiling script, instead of hacking CMakeList.txt 

@emailweixu if you feel free, can verify the following solution in your test environment.
 ```
 cmake_minimum_required(VERSION 3.2) 
```

How about your suggestions. @reyoung @emailweixu @wangkuiyi 

