### PR TITLE
Fix minor errors in instructions of building Paddle on Mac OS X

### DIFF
--- a/doc/build/build_from_source.md
+++ b/doc/build/build_from_source.md
@@ -219,10 +219,9 @@ easy_install pip
   # Install google test on Mac OS X
   # Download gtest 1.7.0
   wget https://github.com/google/googletest/archive/release-1.7.0.tar.gz
-  tar -xvf googletest-release-1.7.0.tar.gz && cd googletest-release-1.7.0
+  tar -xzf googletest-release-1.7.0.tar.gz && cd googletest-release-1.7.0
   # Build gtest
-  mkdir build && cmake ..
-  make
+  mkdir build && cd build && cmake .. && make
   # Install gtest library
   sudo cp -r ../include/gtest /usr/local/include/
   sudo cp lib*.a /usr/local/lib


### PR DESCRIPTION
In our document, there are a few minor errors in the building procedure of Paddle on Mac OS X. Here is the fix.