### PR TITLE
Fix glog check type unmatch in Util.cpp

### DIFF
--- a/paddle/utils/Util.cpp
+++ b/paddle/utils/Util.cpp
@@ -106,7 +106,7 @@ pid_t getTID() {
       #endif
       pid_t tid = syscall(__NR_gettid);
   #endif
-  CHECK_NE(tid, -1);
+  CHECK_NE(static_cast<long>(tid), -1L);
   return tid;
 }
 

--- a/paddle/utils/Util.cpp
+++ b/paddle/utils/Util.cpp
@@ -106,7 +106,7 @@ pid_t getTID() {
       #endif
       pid_t tid = syscall(__NR_gettid);
   #endif
-  CHECK_NE(static_cast<long>(tid), -1L);
+  CHECK_NE(static_cast<int64>(tid), -1L);
   return tid;
 }
 

--- a/paddle/utils/Util.cpp
+++ b/paddle/utils/Util.cpp
@@ -106,7 +106,7 @@ pid_t getTID() {
       #endif
       pid_t tid = syscall(__NR_gettid);
   #endif
-  CHECK_NE(static_cast<int64>(tid), -1L);
+  CHECK_NE((int)tid, -1);
   return tid;
 }
 


### PR DESCRIPTION
#352  @reyoung @backyes @wangkuiyi 
Currently, Paddle exists lots of the similar problems about unmatched data type comparison. 