### PR TITLE
modify the format of diff information in protostr

### DIFF
--- a/python/paddle/trainer_config_helpers/tests/configs/run_tests.sh
+++ b/python/paddle/trainer_config_helpers/tests/configs/run_tests.sh
@@ -13,5 +13,5 @@ for file in $files
 do
     base_protostr=$protostr/$file
     new_protostr=$protostr/$file.unitest
-    diff $base_protostr $new_protostr
+    diff $base_protostr $new_protostr -u
 done


### PR DESCRIPTION
当protostr格式发生改变时，原来的打印结果如下：
```
45: 6a7,8
45: >   height: 0
45: >   width: 0
45: 28a31,32
45: >       output_y: 227
45: >       img_size_y: 256
45: 33a38,39
45: >   height: 227
45: >   width: 227
```
当多个protostr都发生变化时，看不出是哪个发生变化，也很难看出哪里修改了。


目前改成如下格式，方便大家找出对应的文件和对应修改的行：
```
45: --- /home/luotao/Paddle/python/paddle/trainer_config_helpers/tests/configs/protostr/img_layers.protostr     2016-11-07 15:16:54.000000000 +0800
45: +++ /home/luotao/Paddle/python/paddle/trainer_config_helpers/tests/configs/protostr/img_layers.protostr.unitest     2016-11-08 17:06:16.000000000 +0800
45: @@ -4,6 +4,8 @@
45:    type: "data"
45:    size: 65536
45:    active_type: ""
45: +  height: 0
45: +  width: 0
45:  }
45:  layers {
45:    name: "__conv_0__"
45: @@ -26,11 +28,15 @@
45:        filter_size_y: 32
45:        padding_y: 1
45:        stride_y: 1
45: +      output_y: 227
45: +      img_size_y: 256
45:      }
45:    }
45:    bias_parameter_name: "___conv_0__.wbias"
45:    num_filters: 64
45:    shared_biases: true
45: +  height: 227
45: +  width: 227
45:  }
45:  layers {
45:    name: "__batch_norm_0__"
```
