### PR TITLE
use yapf to format python code, add style config file

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,5 @@
+[style]
+based_on_style = google
+indent_width = 4
+spaces_before_comment = 4
+split_before_logical_operator = true


### PR DESCRIPTION
1 use yapf  ( https://github.com/google/yapf)   to format python code, and add .style.yapf config file #254 
2 contributors can add a git hooks to auto-format changed python code just like this
```
cat .git/hooks/pre-commit
```

```
#!/bin/bash

function python_style_check() {
    #check python code in a git repo
    root=`git rev-parse --show-toplevel`
    exit=0
    for file in `git diff --staged --name-only|grep '\.py$'`; do
        yapf -i --style=$root/.style.yapf $root/$file        
        if [ $? -ne 0 ]; then
            let exit=1
        fi
        git add $root/$file
    done
    exit $exit
}
python_style_check
```