### PR TITLE
fix bug for issue 345

### DIFF
--- a/demo/sentiment/data/get_imdb.sh
+++ b/demo/sentiment/data/get_imdb.sh
@@ -38,11 +38,11 @@ unzip master.zip
 mkdir -p imdb/train
 mkdir -p imdb/test
 
-cp -r aclImdb/train/pos/ imdb/train/
-cp -r aclImdb/train/neg/ imdb/train/
+cp -r aclImdb/train/pos/ imdb/train/pos
+cp -r aclImdb/train/neg/ imdb/train/neg
 
-cp -r aclImdb/test/pos/ imdb/test/
-cp -r aclImdb/test/neg/ imdb/test/
+cp -r aclImdb/test/pos/ imdb/test/pos
+cp -r aclImdb/test/neg/ imdb/test/neg
 
 #remove compressed package
 rm aclImdb_v1.tar.gz


### PR DESCRIPTION
fix bug for issue 345

bug原因：
mac下cp命令不能递归拷贝时会将子目录下的文件打平拷贝到目标目录，而不是将目录一块拷贝